### PR TITLE
made floating-point-bytes->real work on 32bit platforms

### DIFF
--- a/pycket/prims/numeric.py
+++ b/pycket/prims/numeric.py
@@ -492,9 +492,9 @@ def integer_bytes_to_integer(bstr, signed):
         raise SchemeException(
                 "floating-point-bytes->real: byte string must have length 2, 4, or 8")
 
-    val = 0
+    val = rarithmetic.r_int64(0)
     for i, v in enumerate(bytes):
-        val += ord(v) << (i * 8)
+        val += rarithmetic.r_int64(ord(v)) << (i * 8)
 
     return values.W_Flonum(longlong2float.longlong2float(val))
 


### PR DESCRIPTION
PR to fix issue #203 

floating-point-bytes->real operates on 64bit integers. This fix changes two lines of code to make sure that int64 operations are used (even on 32bit platforms).

Fix has been tested on 64bit and 32bit platforms.
