### PR TITLE
Update the command for cloning Pypy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ clean-racket:
 	rm -rf racket
 
 clone-pypy:
-	hg clone https://bitbucket.org/pypy/pypy
+	hg clone https://foss.heptapod.net/pypy/pypy pypy
 
 make-pypy:
 	$(MAKE) -C pypy


### PR DESCRIPTION
The URL for the repo has changed.
The updated command follows the canonical instructions:
https://doc.pypy.org/en/latest/build.html#clone-the-repository